### PR TITLE
Change default datetime in query from '0000-00-00' to '1970-01-01'

### DIFF
--- a/php/include/PLUSPEOPLE/PesaPi/Base/Transaction.php
+++ b/php/include/PLUSPEOPLE/PesaPi/Base/Transaction.php
@@ -219,7 +219,7 @@ class Transaction {
                               '$type',
                               '$superType',
                               '',
-                              '0000-00-00',
+                              '1970-01-01',
                               '',
                               '',
                               '',

--- a/php/include/PLUSPEOPLE/PesaPi/MpesaPrivate/MpesaPrivate.php
+++ b/php/include/PLUSPEOPLE/PesaPi/MpesaPrivate/MpesaPrivate.php
@@ -63,19 +63,23 @@ class MpesaPrivate extends \PLUSPEOPLE\PesaPi\Base\Account {
 			$parser = new PersonalParser();
 			$temp = $parser->parse($message);
 
-			$transaction = Transaction::createNew($this->getId(), $temp['SUPER_TYPE'], $temp['TYPE']);
-			$transaction->setReceipt($temp['RECEIPT']);
-			$transaction->setTime($temp["TIME"]);
-			$transaction->setPhonenumber($temp['PHONE']);
-			$transaction->setName($temp['NAME']);
-			$transaction->setAccount($temp['ACCOUNT']);
-			$transaction->setStatus($temp['STATUS']);
-			$transaction->setAmount($temp['AMOUNT']);
-			$transaction->setPostBalance($temp['BALANCE']);
-			$transaction->setNote($temp['NOTE']);
- 			$transaction->setTransactionCost($temp['COST']);
-			
-			$transaction->update();
+			if($temp['AMOUNT'] > 0) {
+				$transaction = Transaction::createNew($this->getId(), $temp['SUPER_TYPE'], $temp['TYPE']);
+				$transaction->setReceipt($temp['RECEIPT']);
+				$transaction->setTime($temp["TIME"]);
+				$transaction->setPhonenumber($temp['PHONE']);
+				$transaction->setName($temp['NAME']);
+				$transaction->setAccount($temp['ACCOUNT']);
+				$transaction->setStatus($temp['STATUS']);
+				$transaction->setAmount($temp['AMOUNT']);
+				$transaction->setPostBalance($temp['BALANCE']);
+				$transaction->setNote($temp['NOTE']);
+				$transaction->setTransactionCost($temp['COST']);
+				
+				$transaction->update();
+			} else {
+				return true;
+			}
 
 			// Callback if needed
 			$this->handleCallback($transaction);


### PR DESCRIPTION
Recent versions of MySQL do not allow `0000-00-00` so the default Transaction database query keeps failing causing a `null` value on the `setReceipt()` function. Change to epoch which is allowed

Fixes #22